### PR TITLE
0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,8 @@ pip install WedgieIntegrator
 ### 0.1.3, 2024-08-09
 A few fixes, and better support for pagination with a custom response object and/or POST requests
 
-# ToDo
-- Add pagination option where the response can provide all remaining links at once
-- Add automatic wait & retry for rate limit errors (currently handled by integrations themselves)
-- More tests
-- Documentation
-- sample scripts, or perhaps a library of specific API configurations
-
-- kinda done: Add rate limiting (safe for Python 3.7)
+### 0.1.4, 2024-08-26
+Breaking change: will no longer return a different number of object (tuple vs single object) when pagination is detected.
+From now on, a single object will always be returned. When pagination is used, two new properties become useful:
+- "paginated_responses" is a combined list of all responses, from first to last
+- "paginated_results" is a combined list of all results from all paginated responses

--- a/WedgieIntegrator/response.py
+++ b/WedgieIntegrator/response.py
@@ -1,7 +1,7 @@
 from typing import Optional, Any, Type, Union
-
 import httpx
 from pydantic import BaseModel
+
 try:
     from asyncio import to_thread
 except ImportError:
@@ -16,7 +16,7 @@ class BaseAPIResponse:
     is_pagination: bool = False
     link_header: str = None
     pagination_links: dict = None
-    __content = None
+    _content = None
     _client = None
     result_limit: int = None
 
@@ -35,7 +35,7 @@ class BaseAPIResponse:
     @property
     def content(self) -> Union[dict, list, Any]:
         # Remember that this is not accessible until after initialization, because _async_parse_content has to run first
-        return self.__content
+        return self._content
 
     @property
     def result_list(self):
@@ -63,13 +63,13 @@ class BaseAPIResponse:
     async def _async_parse_content(self):
         if self.response_model:
             parsed_response = await to_thread(self.response.json)
-            self.__content = self.response_model.parse_obj(parsed_response)
+            self._content = self.response_model.parse_obj(parsed_response)
         elif await self.is_json():
-            self.__content = await to_thread(self.response.json)
+            self._content = await to_thread(self.response.json)
         elif 'text/' in self.content_type:
-            self.__content = self.response.text
+            self._content = self.response.text
         else:
-            self.__content = self.response.content
+            self._content = self.response.content
 
 
 class APIResponse(BaseAPIResponse):

--- a/WedgieIntegrator/response.py
+++ b/WedgieIntegrator/response.py
@@ -96,6 +96,18 @@ class BaseAPIResponse:
         else:
             self._content = self.response.content
 
+    @property
+    def paginated_responses(self) -> list:
+        # By making this a property, we ensure that it can't be overwritten, i.e. it always remains the same object
+        # But it also makes it easier to override in subclasses
+        return self.__paginated_responses
+
+    @property
+    def paginated_results(self) -> list:
+        if not isinstance(self.paginated_responses, list):
+            return []
+        return [result for response in self.paginated_responses for result in response.result_list][:self.result_limit]
+
 
 class APIResponse(BaseAPIResponse):
 

--- a/WedgieIntegrator/response.py
+++ b/WedgieIntegrator/response.py
@@ -12,20 +12,31 @@ class BaseAPIResponse:
     response: httpx.Response
     response_model: Optional[Type[BaseModel]] = None
     content_type: str
-    is_rate_limit_failure: bool = False
-    is_pagination: bool = False
-    link_header: str = None
-    pagination_links: dict = None
-    _content = None
-    _client = None
     result_limit: int = None
+    link_header: str = None
+    _is_pagination: bool = None
+    _content: Any = None
+    _client = None
 
     def __init__(self, api_client, response: httpx.Response, response_model: Optional[Type[BaseModel]] = None, result_limit: int = None):
         self._client = api_client
         self.response = response
         self.response_model = response_model
         self.content_type = response.headers.get('Content-Type', '')
-        self.result_limit = result_limit
+        if isinstance(result_limit, int) and result_limit > 0:
+            self.result_limit = result_limit
+        self.__pagination_links = {}
+        self.__paginated_responses = []
+
+    @property
+    def is_pagination(self) -> bool:
+        if self._is_pagination is not None:
+            return self._is_pagination
+        return False
+
+    @is_pagination.setter
+    def is_pagination(self, value):
+        self._is_pagination = value
 
     @property
     def is_rate_limit_error(self):
@@ -33,15 +44,24 @@ class BaseAPIResponse:
             return True
 
     @property
+    def is_rate_limit_failure(self):
+        return False
+
+    @property
     def content(self) -> Union[dict, list, Any]:
         # Remember that this is not accessible until after initialization, because _async_parse_content has to run first
         return self._content
+
+    @content.setter
+    def content(self, value):
+        self._content = value
 
     @property
     def result_list(self):
         """Customizable property for returning results as a list, when applicable"""
         if isinstance(self.content, list):
             return self.content
+        return []
 
     async def is_json(self):
         """Standalone parser to make customization easy"""
@@ -50,9 +70,14 @@ class BaseAPIResponse:
         return False
 
     @property
+    def pagination_links(self) -> dict:
+        # By making this a property, we ensure that it can't be overwritten, i.e. it always remains the same object
+        # But it also makes it easier to override in subclasses
+        return self.__pagination_links
+
+    @property
     def pagination_next_link(self):
-        if self.pagination_links:
-            return self.pagination_links.get('next')
+        return self.pagination_links.get('next')
 
     async def get_pagination_payload(self):
         request_args = {}
@@ -78,7 +103,6 @@ class APIResponse(BaseAPIResponse):
         super().__init__(*args, **kwargs)
         self.link_header = self.response.headers.get('Link')
         if self.link_header:
-            self.pagination_links = {}
             for link in self.link_header.split(','):
                 parts = link.split(';')
                 url = parts[0].strip('<> ')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = WedgieIntegrator
-version = 0.1.3.2
+version = 0.1.4.0
 author = Chad Roberts
 author_email = jcbroberts@gmail.com
 description = An API client toolkit that is async friendly

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="WedgieIntegrator",
-    version="0.1.3.2",
+    version="0.1.4.0",
     author="Chad Roberts",
     author_email="jcbroberts@gmail.com",
     description="An API client toolkit that is async friendly",


### PR DESCRIPTION
Breaking change: will no longer return a different number of object (tuple vs single object) when pagination is detected.
From now on, a single object will always be returned. When pagination is used, two new properties become useful:
- "paginated_responses" is a combined list of all responses, from first to last
- "paginated_results" is a combined list of all results from all paginated responses
